### PR TITLE
Remove ament_python from buildtool

### DIFF
--- a/stretch_core/package.xml
+++ b/stretch_core/package.xml
@@ -48,7 +48,6 @@
   <!--   <test_depend>gtest</test_depend> -->
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
-  <buildtool_depend>ament_python</buildtool_depend>
   <build_depend>actionlib_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>


### PR DESCRIPTION
There's no need since it's not a build tool