### PR TITLE
Thursday fixes

### DIFF
--- a/stretch_core/stretch_core/stretch_driver.py
+++ b/stretch_core/stretch_core/stretch_driver.py
@@ -560,9 +560,10 @@ class StretchBodyNode(Node):
 
         # ~ symbol gets parameter from private namespace
         self.joint_state_rate = self.get_parameter('rate').value
-        self.timeout = self.get_parameter('timeout').value
+        self.timeout_s = self.get_parameter('timeout').value
+        self.timeout = Duration(seconds=self.timeout_s)
         self.get_logger().info("{0} rate = {1} Hz".format(self.node_name, self.joint_state_rate))
-        self.get_logger().info("{0} timeout = {1} s".format(self.node_name, self.timeout))
+        self.get_logger().info("{0} timeout = {1} s".format(self.node_name, self.timeout_s))
 
         self.use_fake_mechaduinos = self.get_parameter('use_fake_mechaduinos').value
         self.get_logger().info("{0} use_fake_mechaduinos = {1}".format(self.node_name, self.use_fake_mechaduinos))
@@ -636,7 +637,6 @@ def main():
     rclpy.init()
     node = StretchBodyNode()
     node.main()
-    node.destroy_node()
     rclpy.shutdown()
 
 

--- a/stretch_moveit_config/config/moveit_simple_controllers.yaml
+++ b/stretch_moveit_config/config/moveit_simple_controllers.yaml
@@ -1,8 +1,8 @@
 controller_names:
-  - stretch_arm_controller
+  - stretch_controller
   - gripper_controller
 
-stretch_arm_controller:
+stretch_controller:
     action_ns: follow_joint_trajectory
     default: True
     type: FollowJointTrajectory

--- a/stretch_moveit_config/config/ros_controllers.yaml
+++ b/stretch_moveit_config/config/ros_controllers.yaml
@@ -2,7 +2,7 @@ controller_manager:
   ros__parameters:
     update_rate: 2  # Hz
 
-    stretch_arm_controller:
+    stretch_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
     joint_state_controller:
@@ -11,7 +11,7 @@ controller_manager:
     gripper_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
-stretch_arm_controller:
+stretch_controller:
   ros__parameters:
     joints:
       - joint_lift

--- a/stretch_moveit_config/config/stretch_description.srdf
+++ b/stretch_moveit_config/config/stretch_description.srdf
@@ -26,6 +26,13 @@
         <link name="link_gripper_finger_right"/>
         <link name="link_gripper_fingertip_right"/>
     </group>
+    <group name="position">
+        <joint name="position" />
+    </group>
+    <group name="mobile_base_arm">
+        <group name="stretch_arm" />
+        <group name="position" />
+    </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="home" group="stretch_arm">
         <joint name="joint_arm_l0" value="0"/>
@@ -43,13 +50,6 @@
         <joint name="joint_lift" value="1.1"/>
         <joint name="joint_wrist_yaw" value="4"/>
     </group_state>
-    <group name="position">
-        <joint name="position" />
-    </group>
-    <group name="mobile_base_arm">
-        <group name="stretch_arm" />
-        <group name="position" />
-    </group>
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <end_effector name="gripper" parent_link="link_grasp_center" group="stretch_arm"/>
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->

--- a/stretch_moveit_config/launch/demo.launch.py
+++ b/stretch_moveit_config/launch/demo.launch.py
@@ -120,7 +120,7 @@ def generate_launch_description():
         )
         ld.add_action(fake_joint_driver_node)
 
-        for controller in ["stretch_arm_controller", "gripper_controller", "joint_state_controller"]:
+        for controller in ["stretch_controller", "gripper_controller", "joint_state_controller"]:
             ld.add_action(
                 ExecuteProcess(
                     cmd=["ros2 run controller_manager spawner.py {}".format(controller)],


### PR DESCRIPTION
Fixes four bugs: 
 * Renames `stretch_arm_controller` to `stretch_controller` to match the [namespace in the real driver](https://github.com/PickNikRobotics/stretch_ros/blob/37f2a30303ba37047ab5f3b5f02e973836d6626e/stretch_core/stretch_core/joint_trajectory_server.py#L19)
 * Saves `self.timeout` as a Duration in `stretch_driver` so that [comparisons can be done automatically against other durations](https://github.com/PickNikRobotics/stretch_ros/blob/37f2a30303ba37047ab5f3b5f02e973836d6626e/stretch_core/stretch_core/stretch_driver.py#L94)
 * Removes the manual call to `destroy_node` because otherwise an error message is printed on exit when it tries to destroy the action server. 
 * Reorders the srdf just for cleanliness.