### PR TITLE
Simplify actions

### DIFF
--- a/stretch_moveit_config/config/kinematics.yaml
+++ b/stretch_moveit_config/config/kinematics.yaml
@@ -6,3 +6,7 @@ mobile_base_arm:
   kinematics_solver: stretch_kinematics_plugin/StretchKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.1
+stretch_head:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.1

--- a/stretch_moveit_config/config/moveit_simple_controllers.yaml
+++ b/stretch_moveit_config/config/moveit_simple_controllers.yaml
@@ -12,5 +12,7 @@ stretch_controller:
       - joint_arm_l1
       - joint_arm_l0
       - joint_wrist_yaw
+      - joint_head_pan
+      - joint_head_tilt
       - joint_gripper_finger_left
       - joint_gripper_finger_right

--- a/stretch_moveit_config/config/moveit_simple_controllers.yaml
+++ b/stretch_moveit_config/config/moveit_simple_controllers.yaml
@@ -1,6 +1,5 @@
 controller_names:
   - stretch_controller
-  - gripper_controller
 
 stretch_controller:
     action_ns: follow_joint_trajectory
@@ -13,11 +12,5 @@ stretch_controller:
       - joint_arm_l1
       - joint_arm_l0
       - joint_wrist_yaw
-
-gripper_controller:
-    action_ns: follow_joint_trajectory
-    default: True
-    type: FollowJointTrajectory
-    joints:
       - joint_gripper_finger_left
       - joint_gripper_finger_right

--- a/stretch_moveit_config/config/ompl_planning.yaml
+++ b/stretch_moveit_config/config/ompl_planning.yaml
@@ -181,3 +181,30 @@ gripper:
     - LazyPRMstar
     - SPARS
     - SPARStwo
+stretch_head:
+  default_planner_config: RRTConnect
+  planner_configs:
+    - AnytimePathShortening
+    - SBL
+    - EST
+    - LBKPIECE
+    - BKPIECE
+    - KPIECE
+    - RRT
+    - RRTConnect
+    - RRTstar
+    - TRRT
+    - PRM
+    - PRMstar
+    - FMT
+    - BFMT
+    - PDST
+    - STRIDE
+    - BiTRRT
+    - LBTRRT
+    - BiEST
+    - ProjEST
+    - LazyPRM
+    - LazyPRMstar
+    - SPARS
+    - SPARStwo

--- a/stretch_moveit_config/config/ros_controllers.yaml
+++ b/stretch_moveit_config/config/ros_controllers.yaml
@@ -18,5 +18,7 @@ stretch_controller:
       - joint_arm_l1
       - joint_arm_l0
       - joint_wrist_yaw
+      - joint_head_pan
+      - joint_head_tilt
       - joint_gripper_finger_left
       - joint_gripper_finger_right

--- a/stretch_moveit_config/config/ros_controllers.yaml
+++ b/stretch_moveit_config/config/ros_controllers.yaml
@@ -8,11 +8,9 @@ controller_manager:
     joint_state_controller:
       type: joint_state_controller/JointStateController
 
-    gripper_controller:
-      type: joint_trajectory_controller/JointTrajectoryController
-
 stretch_controller:
   ros__parameters:
+    allow_partial_joints_goal: true
     joints:
       - joint_lift
       - joint_arm_l3
@@ -20,9 +18,5 @@ stretch_controller:
       - joint_arm_l1
       - joint_arm_l0
       - joint_wrist_yaw
-
-gripper_controller:
-  ros__parameters:
-    joints:
       - joint_gripper_finger_left
       - joint_gripper_finger_right

--- a/stretch_moveit_config/config/stretch.xacro
+++ b/stretch_moveit_config/config/stretch.xacro
@@ -8,9 +8,11 @@
     <xacro:if value="$(arg use_fake_controller)">
         <!-- Import stretch ros2_control description -->
         <xacro:include filename="stretch_arm.ros2_control.xacro" />
+        <xacro:include filename="stretch_head.ros2_control.xacro" />
         <xacro:include filename="gripper.ros2_control.xacro" />
 
         <xacro:stretch_arm_ros2_control name="StretchFakeJointDriver" />
+        <xacro:stretch_head_ros2_control name="StretchHeadFakeJointDriver" />
         <xacro:gripper_ros2_control name="StretchGripperFakeJointDriver" />
     </xacro:if>
 </robot>

--- a/stretch_moveit_config/config/stretch_description.srdf
+++ b/stretch_moveit_config/config/stretch_description.srdf
@@ -33,6 +33,11 @@
         <group name="stretch_arm" />
         <group name="position" />
     </group>
+    <group name="stretch_head">
+        <joint name="joint_head_pan" />
+        <joint name="joint_head_tilt" />
+        <link name="camera_link"/>
+    </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="home" group="stretch_arm">
         <joint name="joint_arm_l0" value="0"/>
@@ -49,6 +54,18 @@
         <joint name="joint_arm_l3" value="0.13"/>
         <joint name="joint_lift" value="1.1"/>
         <joint name="joint_wrist_yaw" value="4"/>
+    </group_state>
+    <group_state name="home" group="stretch_head">
+        <joint name="joint_head_pan" value="0.0"/>
+        <joint name="joint_head_tilt" value="0.0"/>
+    </group_state>
+    <group_state name="low_head" group="stretch_head">
+        <joint name="joint_head_pan" value="-3.5"/>
+        <joint name="joint_head_tilt" value="-1.2"/>
+    </group_state>
+    <group_state name="high_head" group="stretch_head">
+        <joint name="joint_head_pan" value="1.0"/>
+        <joint name="joint_head_tilt" value="0.5"/>
     </group_state>
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <end_effector name="gripper" parent_link="link_grasp_center" group="stretch_arm"/>

--- a/stretch_moveit_config/config/stretch_head.ros2_control.xacro
+++ b/stretch_moveit_config/config/stretch_head.ros2_control.xacro
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+    <xacro:macro name="stretch_head_ros2_control" params="name">
+
+        <ros2_control name="${name}" type="system">
+            <hardware>
+                <plugin>fake_components/GenericSystem</plugin>
+            </hardware>
+            <joint name="joint_head_pan">
+                <param name="initial_position">0.0</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="joint_head_tilt">
+                <param name="initial_position">0.0</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+        </ros2_control>
+
+    </xacro:macro>
+
+</robot>

--- a/stretch_moveit_config/launch/demo.launch.py
+++ b/stretch_moveit_config/launch/demo.launch.py
@@ -120,7 +120,7 @@ def generate_launch_description():
         )
         ld.add_action(fake_joint_driver_node)
 
-        for controller in ["stretch_controller", "gripper_controller", "joint_state_controller"]:
+        for controller in ["stretch_controller", "joint_state_controller"]:
             ld.add_action(
                 ExecuteProcess(
                     cmd=["ros2 run controller_manager spawner.py {}".format(controller)],


### PR DESCRIPTION
The real stretch driver has [one action server that controls as many joints as needed.](https://github.com/PickNikRobotics/stretch_ros/blob/e0b5d101e898df2640a847d67f713dd36d4b764a/stretch_core/stretch_core/joint_trajectory_server.py#L19)

Hence we do not need a separate gripper config like initially configured, nor a separate head controller like in #9. 

This PR removes the separate gripper config and adds the joints needed for controlling the head. Crucially, it also sets `allow_partial_joints_goal` to true so that any subset can be run, and you don't need ALL the joints. 