### PR TITLE
Add position to list of joints

### DIFF
--- a/stretch_moveit_config/config/moveit_simple_controllers.yaml
+++ b/stretch_moveit_config/config/moveit_simple_controllers.yaml
@@ -16,3 +16,4 @@ stretch_controller:
       - joint_head_tilt
       - joint_gripper_finger_left
       - joint_gripper_finger_right
+      - position

--- a/stretch_moveit_config/config/ros_controllers.yaml
+++ b/stretch_moveit_config/config/ros_controllers.yaml
@@ -22,3 +22,4 @@ stretch_controller:
       - joint_head_tilt
       - joint_gripper_finger_left
       - joint_gripper_finger_right
+      - position


### PR DESCRIPTION
The change to `moveit_simple_controllers.yaml` allows `move_group` to command the base. 

The change to `ros_controllers.yaml` theoretically allows for a fake controller for `position`. 