### PR TITLE
Trajectory Components for FollowJointTrajectory

### DIFF
--- a/stretch_core/stretch_core/action_exceptions.py
+++ b/stretch_core/stretch_core/action_exceptions.py
@@ -3,7 +3,12 @@ from control_msgs.action import FollowJointTrajectory
 
 # Exceptions for dealing with FollowJointTrajectory
 class FollowJointTrajectoryException(RuntimeError):
-    pass
+    """Parent class for all FollowJointTrajectory errors.
+
+    Each subclass should define the CODE based on the constants in FollowJointTrajectory.Result.
+    """
+
+    CODE = -100  # Arbitrary constant for unknown error.
 
 
 class InvalidGoalException(FollowJointTrajectoryException):

--- a/stretch_core/stretch_core/action_exceptions.py
+++ b/stretch_core/stretch_core/action_exceptions.py
@@ -1,0 +1,15 @@
+from control_msgs.action import FollowJointTrajectory
+
+
+# Exceptions for dealing with FollowJointTrajectory
+class FollowJointTrajectoryException(RuntimeError):
+    pass
+
+
+class InvalidGoalException(FollowJointTrajectoryException):
+    CODE = FollowJointTrajectory.Result.INVALID_GOAL
+
+
+class InvalidJointException(FollowJointTrajectoryException):
+    CODE = FollowJointTrajectory.Result.INVALID_JOINTS
+

--- a/stretch_core/stretch_core/trajectory_components.py
+++ b/stretch_core/stretch_core/trajectory_components.py
@@ -1,0 +1,62 @@
+from hello_helpers.hello_misc import to_sec
+
+
+class TrajectoryComponent:
+    def __init__(self, name, trajectory_manager):
+        self.name = name
+        self.trajectory_manager = trajectory_manager
+
+    def get_position(self):
+        return self.trajectory_manager.status['pos']
+
+    def get_velocity(self):
+        return self.trajectory_manager.status['vel']
+
+    def get_desired_position(self, dt):
+        return self.trajectory_manager.trajectory.evaluate_at(dt).position
+
+    def add_waypoints(self, waypoints, index):
+        self.trajectory_manager.trajectory.clear_waypoints()
+        for waypoint in waypoints:
+            t = to_sec(waypoint.time_from_start)
+            x = waypoint.positions[index]
+            v = waypoint.velocities[index] if index < len(waypoint.velocities) else None
+            a = waypoint.accelerations[index] if index < len(waypoint.accelerations) else None
+            self.add_waypoint(t, x, v, a)
+
+    def add_waypoint(self, t, x, v, a):
+        self.trajectory_manager.trajectory.add_waypoint(t, x, v, a)
+
+
+class HeadPanComponent(TrajectoryComponent):
+    def __init__(self, robot):
+        TrajectoryComponent.__init__(self, 'joint_head_pan', robot.head.get_joint('head_pan'))
+
+
+class HeadTiltComponent(TrajectoryComponent):
+    def __init__(self, robot):
+        TrajectoryComponent.__init__(self, 'joint_head_tilt', robot.head.get_joint('head_tilt'))
+
+
+class WristYawComponent(TrajectoryComponent):
+    def __init__(self, robot):
+        TrajectoryComponent.__init__(self, 'joint_wrist_yaw', robot.end_of_arm.motors['wrist_yaw'])
+
+
+class ArmComponent(TrajectoryComponent):
+    def __init__(self, robot):
+        TrajectoryComponent.__init__(self, 'wrist_extension', robot.arm)
+
+
+class LiftComponent(TrajectoryComponent):
+    def __init__(self, robot):
+        TrajectoryComponent.__init__(self, 'joint_lift', robot.lift)
+
+
+def get_trajectory_components(robot):
+    return {component.name: component for component in [HeadPanComponent(robot),
+                                                        HeadTiltComponent(robot),
+                                                        WristYawComponent(robot),
+                                                        ArmComponent(robot),
+                                                        LiftComponent(robot),
+                                                        ]}

--- a/stretch_core/stretch_core/trajectory_components.py
+++ b/stretch_core/stretch_core/trajectory_components.py
@@ -12,7 +12,7 @@ class TrajectoryComponent:
     def get_velocity(self):
         return self.trajectory_manager.status['vel']
 
-    def get_desired_position(self, dt):
+    def get_desired_position_at(self, dt):
         return self.trajectory_manager.trajectory.evaluate_at(dt).position
 
     def add_waypoints(self, waypoints, index):


### PR DESCRIPTION
A couple more pieces for #37. 

 * First, we introduce the TrajectoryComponent class which is a light wrapper around the [`TrajectoryManager` class](https://github.com/hello-robot/stretch_body/blob/3500c22ad74a5fd57711165664b0010730e51361/body/stretch_body/trajectory_managers.py#L477). It is modularized in a way that will make it easy to extend/customize it when we add the Gripper and Base classes. 
 * Second, we add the concept of `FollowJointTrajectoryException`s and their derived classes which make aborting the action with a specific error code/message much easier. 
 * Then we use these pieces in our FollowJointTrajectory implementation, first by checking parts of the goal, and then by actually adding the waypoints. 